### PR TITLE
Minor tidy of words

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The cs3api-validator is a tool to test implementations of the [CS3Apis](https://
 
 ### BDD (Behavior driven development)
 
-The cs3api-validator can be run locally in a development phase to develop against a well defined set of basic API operations. It has no external dependencies and runs human readable gherkin test scenarios. This helps to understand the behavior of the CS3APIs being an additional way of documenting the API in combination with the specification.
+The cs3api-validator can be run locally in a development phase to develop against a well-defined set of basic API operations. It has no external dependencies and runs human-readable gherkin test scenarios. This helps to understand the behavior of the CS3APIs being an additional way of documenting the API in combination with the specification.
 
 ### Litmus Testing
 
@@ -127,7 +127,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 ### Run with go test
 
-You can run the tests with the built in go test command. The command passes its flags to the godog test suite. The test suite needs one flag to be set: The network address of the running system under test. It defaults to `localhost:9142` and you can set it using the ``--endpoint``flag.
+You can run the tests with the built-in go test command. The command passes its flags to the godog test suite. The test suite needs one flag to be set: The network address of the running system under test. It defaults to `localhost:9142` and you can set it using the ``--endpoint``flag.
 
 > **_NOTE:_** If you want to use the godog flags you need to prefix them with ``godog.flagname``.
 

--- a/cs3apivalidator_test.go
+++ b/cs3apivalidator_test.go
@@ -18,7 +18,7 @@ var opts = godog.Options{
 // Endpoint GRPC address of a running CS3 implementation
 var Endpoint string
 
-// HTTPinsecure controls wether insecure HTTP connections are allowed or not
+// HTTPinsecure controls whether insecure HTTP connections are allowed or not
 var HTTPinsecure bool
 
 func init() {
@@ -45,6 +45,6 @@ func TestMain(m *testing.M) {
 	os.Exit(status)
 }
 
-// Empty test to suppres the "no tests found" warning
+// Empty test to suppress the "no tests found" warning
 func TestOne(t *testing.T) {
 }

--- a/features/etag-propagation.feature
+++ b/features/etag-propagation.feature
@@ -1,5 +1,5 @@
 Feature: Etag and Treesize propagation
-  As as a oCIS user
+  As a user
   I want to edit files in my directory tree
   And let the clients know by changing the root etag
 

--- a/features/wopi-public-links.feature
+++ b/features/wopi-public-links.feature
@@ -1,5 +1,5 @@
 Feature: WOPI server on public links
-  As as a oCIS user without account
+  As a user without account
   I want to be able to edit office files on public links
   So that I can collaborate with regular users
 

--- a/steps/resources/steps.go
+++ b/steps/resources/steps.go
@@ -163,9 +163,9 @@ func (f *ResourcesFeatureContext) userHasUploadedAFileWithContentInTheHomeDirect
 	if uRes.Status.Code != rpc.Code_CODE_OK {
 		switch uRes.Status.Code {
 		case rpc.Code_CODE_PERMISSION_DENIED:
-			return fmt.Errorf("permission denied to intitiate upload %v", uReq)
+			return fmt.Errorf("permission denied to initiate upload %v", uReq)
 		case rpc.Code_CODE_NOT_FOUND:
-			return fmt.Errorf("target not found to intitiate upload %v", uReq)
+			return fmt.Errorf("target not found to initiate upload %v", uReq)
 		default:
 			return fmt.Errorf("error occurred during upload %v", uReq)
 		}


### PR DESCRIPTION
Fix a few typos and hyphenated words that my IDE suggested.

I adjusted some feature descriptions to remove "as an oCIS user". IMO this repo is a "vanilla" test suite for the CS3 API, so it does not require oCIS.