### PR TITLE
[POC] Add basic file operations

### DIFF
--- a/features/etag-propagation.feature
+++ b/features/etag-propagation.feature
@@ -41,7 +41,7 @@ Feature: Etag and Treesize propagation
     And user "admin" remembers the fileinfo of the resource with the alias "a-sub-folder-B"
     And user "admin" remembers the fileinfo of the resource with the alias "testFolder"
     And user "admin" remembers the fileinfo of the resource with the alias "test2"
-    When user "admin" has moved the resource with alias "a-sub-folder" inside a space to target "a-folder/a-sub-folder-B/a-sub-folder"
+    When user "admin" moves the resource with alias "a-sub-folder" inside a space to target "a-folder/a-sub-folder-B/a-sub-folder"
     Then for user "admin" the etag of the resource with the alias "Admin Home" should have changed
     And for user "admin" the etag of the resource with the alias "a-folder" should have changed
     And for user "admin" the etag of the resource with the alias "a-sub-folder" should not have changed

--- a/features/file-operations.feature
+++ b/features/file-operations.feature
@@ -5,7 +5,7 @@ Feature: Basic File operations
 
   Background: Space Exists
     Given user "marie" has logged in with password "radioactivity"
-    Given user "marie" has created a personal space with the alias "Maries Home"
+    And user "marie" has created a personal space with the alias "Maries Home"
 
     Scenario: Create Folders and files
       Given user "marie" has created a folder "NewFolder" in the home directory with the alias "NewFolder"

--- a/features/file-operations.feature
+++ b/features/file-operations.feature
@@ -1,0 +1,50 @@
+Feature: Basic File operations
+  As a user
+  I want to be able to do basic file operations
+  So that I can organize my files
+
+  Background: Space Exists
+    Given user "marie" has logged in with password "radioactivity"
+    Given user "marie" has created a personal space with the alias "Maries Home"
+
+    Scenario: Create Folders and files
+      Given user "marie" has created a folder "NewFolder" in the home directory with the alias "NewFolder"
+      And user "marie" has uploaded a file "testfile.txt" with content "lorem ipsum" in the home directory with the alias "testfile"
+      When user "marie" lists all resources inside the resource with alias "Maries Home"
+      Then the following resources should be listed in the response:
+        | type      | path         |
+        | container | NewFolder    |
+        | file      | testfile.txt |
+
+    Scenario: Create Tree
+      Given user "marie" has created a folder "A" in the home directory with the alias "A"
+      And user "marie" has created a folder "A/B" in the home directory with the alias "B"
+      And user "marie" has uploaded a file "A/B/testfile.txt" with content "lorem ipsum" in the home directory with the alias "testfile"
+      When user "marie" lists all resources inside the resource with alias "Maries Home"
+      Then the following resources should not be listed in the response:
+        | type      | path         |
+        | container | B            |
+        | file      | testfile.txt |
+      And the following resources should be listed in the response:
+        | type      | path |
+        | container | A    |
+
+  Scenario: Rename resources
+    Given user "marie" has created a folder "A" in the home directory with the alias "A"
+    And user "marie" has uploaded a file "testfile.txt" with content "lorem ipsum" in the home directory with the alias "testfile"
+    When user "marie" lists all resources inside the resource with alias "Maries Home"
+    Then the following resources should be listed in the response:
+      | type      | path         |
+      | container | A            |
+      | file      | testfile.txt |
+    When user "marie" has moved the resource with alias "A" inside a space to target "A-Folder"
+    And user "marie" has moved the resource with alias "testfile" inside a space to target "Test-File.txt"
+    When user "marie" lists all resources inside the resource with alias "Maries Home"
+    Then the following resources should be listed in the response:
+      | type      | path          |
+      | container | A-Folder      |
+      | file      | Test-File.txt |
+    And the following resources should not be listed in the response:
+      | type      | path         |
+      | container | A            |
+      | file      | testfile.txt |

--- a/features/file-operations.feature
+++ b/features/file-operations.feature
@@ -37,8 +37,8 @@ Feature: Basic File operations
       | type      | path         |
       | container | A            |
       | file      | testfile.txt |
-    When user "marie" has moved the resource with alias "A" inside a space to target "A-Folder"
-    And user "marie" has moved the resource with alias "testfile" inside a space to target "Test-File.txt"
+    When user "marie" moves the resource with alias "A" inside a space to target "A-Folder"
+    And user "marie" moves the resource with alias "testfile" inside a space to target "Test-File.txt"
     When user "marie" lists all resources inside the resource with alias "Maries Home"
     Then the following resources should be listed in the response:
       | type      | path          |

--- a/helpers/assert.go
+++ b/helpers/assert.go
@@ -19,13 +19,13 @@ type ExpectedAndActualAssertion func(t assert.TestingT, expected, actual interfa
 // assertActual is a helper function to allow the step function to call
 // assertion functions where you want to compare an actual value to a
 // predefined state like nil, empty or true/false.
-//func assertActual(a actualAssertion, actual interface{}, msgAndArgs ...interface{}) error {
-//	var t asserter
-//	a(&t, actual, msgAndArgs...)
-//	return t.err
-//}
-//
-//type actualAssertion func(t assert.TestingT, actual interface{}, msgAndArgs ...interface{}) bool
+func AssertActual(a actualAssertion, actual interface{}, msgAndArgs ...interface{}) error {
+	var t Asserter
+	a(&t, actual, msgAndArgs...)
+	return t.err
+}
+
+type actualAssertion func(t assert.TestingT, actual interface{}, msgAndArgs ...interface{}) bool
 
 // asserter is used to be able to retrieve the error reported by the called assertion
 type Asserter struct {

--- a/steps/resources/context.go
+++ b/steps/resources/context.go
@@ -18,8 +18,10 @@ func NewResourcesFeatureContext(fc *featurecontext.FeatureContext, sc *godog.Sce
 
 func (f *ResourcesFeatureContext) Register(ctx *godog.ScenarioContext) {
 	// steps
-	ctx.Step(`^no resource should be listed in the response$`, f.NoResourceShouldBeListedInTheResponse)
+	ctx.Step(`^user "([^"]*)" lists all resources inside the resource with alias "([^"]*)"$`, f.userListsAllResourcesInsideTheResourceWithAlias)
 	ctx.Step(`^(\d+) resource(?:s)? of type "([^"]*)" should be listed in the response$`, f.ResourceOfTypeShouldBeListedInTheResponse)
+	ctx.Step(`^no resource should be listed in the response$`, f.NoResourceShouldBeListedInTheResponse)
+	ctx.Step(`^the following resources should (not|)\s?be listed in the response:$`, f.theFollowingResourcesShouldBeListedInTheResponse)
 	ctx.Step(`^user "([^"]*)" has created a folder "([^"]*)" in the home directory with the alias "([^"]*)"$`, f.UserHasCreatedAFolderOfTypeInTheHomeDirectoryWithTheAlias)
 	ctx.Step(`^user "([^"]*)" has uploaded a file "([^"]*)" with content "([^"]*)" in the home directory with the alias "([^"]*)"$`, f.userHasUploadedAFileWithContentInTheHomeDirectoryWithTheAlias)
 	ctx.Step(`^user "([^"]*)" remembers the fileinfo of the resource with the alias "([^"]*)"$`, f.userRemembersTheFileInfoOfTheResourceWithTheAlias)

--- a/steps/resources/context.go
+++ b/steps/resources/context.go
@@ -28,7 +28,7 @@ func (f *ResourcesFeatureContext) Register(ctx *godog.ScenarioContext) {
 	ctx.Step(`^for user "([^"]*)" the etag of the resource with the alias "([^"]*)" should (not|)\s?have changed$`, f.forUserTheEtagOfTheResourceWithTheAliasShouldHaveChanged)
 	ctx.Step(`^for user "([^"]*)" the checksums of the resource with the alias "([^"]*)" should (not|)\s?have changed$`, f.forUserTheChecksumsOfTheResourceWithTheAliasShouldHaveChanged)
 	ctx.Step(`^for user "([^"]*)" the treesize of the resource with the alias "([^"]*)" should be (\d+)$`, f.forUserTheTreesizeOfTheResourceWithTheAliasShouldBe)
-	ctx.Step(`^user "([^"]*)" has moved the resource with alias "([^"]*)" inside a space to target "([^"]*)"$`, f.userHasMovedTheResourceWithAliasInsideASpaceToTarget)
+	ctx.Step(`^user "([^"]*)" moves the resource with alias "([^"]*)" inside a space to target "([^"]*)"$`, f.userMovesTheResourceWithAliasInsideASpaceToTarget)
 
 	// cleanup
 	ctx.After(f.DeleteResourcesAfterScenario)

--- a/steps/resources/steps.go
+++ b/steps/resources/steps.go
@@ -439,7 +439,7 @@ func (f *ResourcesFeatureContext) forUserTheTreesizeOfTheResourceWithTheAliasSho
 	return helpers.AssertExpectedAndActual(assert.Equal, resp.Info.Size, uint64(size))
 }
 
-func (f *ResourcesFeatureContext) userHasMovedTheResourceWithAliasInsideASpaceToTarget(user string, alias string, target string) error {
+func (f *ResourcesFeatureContext) userMovesTheResourceWithAliasInsideASpaceToTarget(user string, alias string, target string) error {
 	reqctx, err := f.GetAuthContext(user)
 	if err != nil {
 		return err

--- a/steps/resources/steps.go
+++ b/steps/resources/steps.go
@@ -284,7 +284,7 @@ func (f *ResourcesFeatureContext) theFollowingResourcesShouldBeListedInTheRespon
 		return fmt.Errorf("empty gherkin table")
 	}
 	if rows[0].Cells[0].Value != "type" && rows[0].Cells[1].Value != "path" {
-		return fmt.Errorf("the first line of the tables needs to be in the form <type><path>")
+		return fmt.Errorf("the first line of the tables needs to be in the form | <type> | <path> |")
 	}
 	var rowsValues []*messages.PickleTableRow
 	// collect row values and leave the table header row out


### PR DESCRIPTION
Needs #8 first

```gherkin
Feature: Basic File operations
  As a user
  I want to be able to do basic file operations
  So that I can organize my files

  Background: Space Exists
    Given user "marie" has logged in with password "radioactivity"
    Given user "marie" has created a personal space with the alias "Maries Home"

    Scenario: Create Folders and files
      Given user "marie" has created a folder "NewFolder" in the home directory with the alias "NewFolder"
      And user "marie" has uploaded a file "testfile.txt" with content "lorem ipsum" in the home directory with the alias "testfile"
      When user "marie" lists all resources inside the resource with alias "Maries Home"
      Then the following resources should be listed in the response:
        | type      | path         |
        | container | NewFolder    |
        | file      | testfile.txt |

    Scenario: Create Tree
      Given user "marie" has created a folder "A" in the home directory with the alias "A"
      And user "marie" has created a folder "A/B" in the home directory with the alias "B"
      And user "marie" has uploaded a file "A/B/testfile.txt" with content "lorem ipsum" in the home directory with the alias "testfile"
      When user "marie" lists all resources inside the resource with alias "Maries Home"
      Then the following resources should not be listed in the response:
        | type      | path         |
        | container | B            |
        | file      | testfile.txt |
      And the following resources should be listed in the response:
        | type      | path |
        | container | A    |

  Scenario: Rename resources
    Given user "marie" has created a folder "A" in the home directory with the alias "A"
    And user "marie" has uploaded a file "testfile.txt" with content "lorem ipsum" in the home directory with the alias "testfile"
    When user "marie" lists all resources inside the resource with alias "Maries Home"
    Then the following resources should be listed in the response:
      | type      | path         |
      | container | A            |
      | file      | testfile.txt |
    When user "marie" has moved the resource with alias "A" inside a space to target "A-Folder"
    And user "marie" has moved the resource with alias "testfile" inside a space to target "Test-File.txt"
    When user "marie" lists all resources inside the resource with alias "Maries Home"
    Then the following resources should be listed in the response:
      | type      | path          |
      | container | A-Folder      |
      | file      | Test-File.txt |
    And the following resources should not be listed in the response:
      | type      | path         |
      | container | A            |
      | file      | testfile.txt |
```